### PR TITLE
Remove unnecessary check `c >= PG_UINT8_MAX + 1`

### DIFF
--- a/src/pg_type_template/templates/src/type_name.c.jinja
+++ b/src/pg_type_template/templates/src/type_name.c.jinja
@@ -116,11 +116,6 @@ pg_type_to_str(pg_type c)
 		pg_type_list_initialized = true;
 	}
 
-	if (c >= PG_UINT8_MAX + 1)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("unexpected type value: %d", c)));
-
 	res = &pg_type_list[c];
 	if (res->name == NULL)
 		ereport(ERROR,


### PR DESCRIPTION
pg_type is uint8 and it cannot be higher than 255. Therefore it doesn't make sense to have this check.
This also will make clang check happy.

Example of warning:
```
warning: result of comparison of constant 256 with expression of type 'pg_type' (aka 'unsigned char') is always false [-Wtautological-constant-out-of-range-compare]
        if (c >= PG_UINT8_MAX + 1)
            ~ ^  ~~~~~~~~~~~~~~~~
```