### PR TITLE
fix extension compilation error for PG16

### DIFF
--- a/src/pg_type_template/templates/src/type_name.c.jinja
+++ b/src/pg_type_template/templates/src/type_name.c.jinja
@@ -193,6 +193,5 @@ Datum
 	}
 
 	Assert(astate != NULL);
-    array = (ArrayType *) makeArrayResult(astate, CurrentMemoryContext);
-    PG_RETURN_ARRAYTYPE_P(array);
+    PG_RETURN_DATUM(makeArrayResult(astate, CurrentMemoryContext));
 }

--- a/src/pg_type_template/templates/src/type_name.c.jinja
+++ b/src/pg_type_template/templates/src/type_name.c.jinja
@@ -175,7 +175,6 @@ Datum
 {{ type_name }}_get_list(PG_FUNCTION_ARGS)
 {
 	ArrayBuildState *astate = NULL;
-	ArrayType *array;
 
 	if (!pg_type_list_initialized)
 	{

--- a/src/pg_type_template/templates/src/type_name.c.jinja
+++ b/src/pg_type_template/templates/src/type_name.c.jinja
@@ -175,6 +175,7 @@ Datum
 {{ type_name }}_get_list(PG_FUNCTION_ARGS)
 {
 	ArrayBuildState *astate = NULL;
+	ArrayType *array;
 
 	if (!pg_type_list_initialized)
 	{
@@ -193,5 +194,6 @@ Datum
 	}
 
 	Assert(astate != NULL);
-	PG_RETURN_ARRAYTYPE_P(makeArrayResult(astate, CurrentMemoryContext));
+    array = (ArrayType *) makeArrayResult(astate, CurrentMemoryContext);
+    PG_RETURN_ARRAYTYPE_P(array);
 }


### PR DESCRIPTION
There is a compilation problem for any extension generated by this template when extension is compiled for PostgreSQL 16.
At least following repositories are not compiled for PostgreSQL 16 and needed code change.
This PR corrects the error. See relevant ticket [DB-983](https://adjustcom.atlassian.net/browse/DB-983) for error details. 

F.Y.I @adjust/database-team @adjust/kpis-team 

[pg-ad_revenue_source](https://github.com/adjust/pg-ad_revenue_source)
[pg-match_type](https://github.com/adjust/pg-match_type)
[pg-purchase_verification_status](https://github.com/adjust/pg-purchase_verification_status)
[pg-rejected_engagement_type](https://github.com/adjust/pg-rejected_engagement_type)
[pg-sk_coarse_conversion_value](https://github.com/adjust/pg-sk_coarse_conversion_value)
[pg-sk_condition_type](https://github.com/adjust/pg-sk_condition_type)
[pg-subscription_event_type](https://github.com/adjust/pg-subscription_event_type)
[pg-unverified_install_reason](https://github.com/adjust/pg-unverified_install_reason)
[wltree](https://github.com/adjust/wltree)

[DB-983]: https://adjustcom.atlassian.net/browse/DB-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ