### PR TITLE
Add compatibility for PG 16

### DIFF
--- a/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
+++ b/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
@@ -1,6 +1,13 @@
 \t
 SET max_parallel_workers_per_gather=4;
-SET force_parallel_mode=on;
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::int >= 160000 THEN
+        EXECUTE 'SET debug_parallel_query = on';
+    ELSE
+        EXECUTE 'SET force_parallel_mode = on';
+    END IF;
+END $$;
 set parallel_setup_cost = 10;
 set parallel_tuple_cost = 0.001;
 CREATE TABLE {{ type_name }}_parallel(v {{ type_name }}) WITH (parallel_workers = 4);

--- a/src/pg_type_template/templates/test/expected/type_name_004_parallel_1.out.jinja
+++ b/src/pg_type_template/templates/test/expected/type_name_004_parallel_1.out.jinja
@@ -1,6 +1,13 @@
 \t
 SET max_parallel_workers_per_gather=4;
-SET force_parallel_mode=on;
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::int >= 160000 THEN
+        EXECUTE 'SET debug_parallel_query = on';
+    ELSE
+        EXECUTE 'SET force_parallel_mode = on';
+    END IF;
+END $$;
 set parallel_setup_cost = 10;
 set parallel_tuple_cost = 0.001;
 CREATE TABLE {{ type_name }}_parallel(v {{ type_name }}) WITH (parallel_workers = 4);

--- a/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
+++ b/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
@@ -1,6 +1,13 @@
 \t
 SET max_parallel_workers_per_gather=4;
-SET force_parallel_mode=on;
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::int >= 160000 THEN
+        EXECUTE 'SET debug_parallel_query = on';
+    ELSE
+        EXECUTE 'SET force_parallel_mode = on';
+    END IF;
+END $$;
 set parallel_setup_cost = 10;
 set parallel_tuple_cost = 0.001;
 


### PR DESCRIPTION
Starting with PostgreSQL 16 force_parallel_mode setting has been renamed into debug_parallel_query.
Use the proper setting name based on PostgreSQL version.