### PR TITLE
fix EXECUTE statements in test on pg-type_template repository

### DIFF
--- a/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
+++ b/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
@@ -5,9 +5,9 @@ SET parallel_tuple_cost = 0.001;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 160000 THEN
-        EXECUTE 'SET debug_parallel_query = on';
+        SET debug_parallel_query = 'on';
     ELSE
-        EXECUTE 'SET force_parallel_mode = on';
+        SET force_parallel_mode = 'on';
     END IF;
 END $$;
 CREATE TABLE {{ type_name }}_parallel(v {{ type_name }}) WITH (parallel_workers = 4);

--- a/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
+++ b/src/pg_type_template/templates/test/expected/type_name_004_parallel.out.jinja
@@ -5,9 +5,9 @@ SET parallel_tuple_cost = 0.001;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 160000 THEN
-        SET debug_parallel_query = 'on';
+        SET debug_parallel_query = on;
     ELSE
-        SET force_parallel_mode = 'on';
+        SET force_parallel_mode = on;
     END IF;
 END $$;
 CREATE TABLE {{ type_name }}_parallel(v {{ type_name }}) WITH (parallel_workers = 4);

--- a/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
+++ b/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
@@ -5,9 +5,9 @@ SET parallel_tuple_cost = 0.001;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 160000 THEN
-        EXECUTE 'SET debug_parallel_query = on';
+        SET debug_parallel_query = 'on';
     ELSE
-        EXECUTE 'SET force_parallel_mode = on';
+        SET force_parallel_mode = 'on';
     END IF;
 END $$;
 

--- a/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
+++ b/src/pg_type_template/templates/test/sql/type_name_004_parallel.sql.jinja
@@ -5,9 +5,9 @@ SET parallel_tuple_cost = 0.001;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 160000 THEN
-        SET debug_parallel_query = 'on';
+        SET debug_parallel_query = on;
     ELSE
-        SET force_parallel_mode = 'on';
+        SET force_parallel_mode = on;
     END IF;
 END $$;
 


### PR DESCRIPTION
fix `EXECUTE` statements for parallel tests introduced by this [PR](https://github.com/adjust/pg_type_template/pull/16)
Note: other affected repositories will be handled by future based on priorities. Let's first correct source first.